### PR TITLE
Throttlestop

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -48,19 +48,30 @@ Apply -75mV offset to GPU, -100mV to all other planes::
 
     $ undervolt --gpu -75 --core -100 --cache -100 --uncore -100 --analogio -100
 
+Generated the command to run to recreate your Throttlestop settings::
+
+    $ undervolt --throttlestop ThrottleStop.ini --tsindex 3
+    undervolt --core -100.5859375
+    $ undervolt --throttlestop ThrottleStop.ini
+    undervolt --core -125.0 --gpu -125.0 --cache -125.0
+
 Usage
 -----
 
 .. code-block:: bash
 
     $ undervolt -h
-    usage: undervolt [-h] [-v] [-f] [--core CORE] [--gpu GPU] [--cache CACHE]
+    usage: undervolt [-h] [-v] [-f] [-r] [--throttlestop THROTTLESTOP]
+                     [--tsindex TSINDEX] [--core CORE] [--gpu GPU] [--cache CACHE]
                      [--uncore UNCORE] [--analogio ANALOGIO]
     optional arguments:
       -h, --help            show this help message and exit
       -v, --verbose         print debug info
       -f, --force           allow setting positive offsets
       -r, --read            read existing values
+      --throttlestop THROTTLESTOP
+                            extract values from ThrottleStop
+      --tsindex TSINDEX     ThrottleStop profile index
       --core CORE           offset (mV)
       --gpu GPU             offset (mV)
       --cache CACHE         offset (mV)
@@ -77,6 +88,7 @@ Undervolting should work on any CPU later then Haswell.
 ===================== ========= ==========
 Lenovo X1 Yoga Gen 2  i7-7600U  Yes
 Dell Xps 15 9550      i7-6700HQ Yes
+Dell Xps 15 9560      i7-7700HQ Yes
 Lenovo Thinkpad T470p i7-7700HQ Yes
 ===================== ========= ==========
 

--- a/undervolt.py
+++ b/undervolt.py
@@ -10,7 +10,10 @@ import os
 from glob import glob
 from struct import pack, unpack
 import subprocess
-import configparser
+try:  # Python3
+    import configparser
+except ImportError:  # Python2
+    import ConfigParser as configparser
 
 PLANES = {
     'core': 0,

--- a/undervolt.py
+++ b/undervolt.py
@@ -17,8 +17,8 @@ PLANES = {
     'cache': 2,
     'uncore': 3,
     'analogio': 4,
-#   'digitalio': 5, # not working?
-}
+    # 'digitalio': 5, # not working?
+    }
 
 
 def write_msr(val, msr=0x150):
@@ -73,6 +73,7 @@ def convert_offset(mV):
 
     """
     return format(convert_rounded_offset(int(round(mV*1.024))), '08x')
+
 
 def unconvert_offset(y):
     """ For a given offset, return a value in mV that could have resulted in
@@ -143,7 +144,7 @@ def pack_offset(plane, offset='0'*8):
         plane=PLANES[plane],
         write=int(offset is not '0'*8),
         offset=offset,
-    ), 0)
+        ), 0)
 
 
 def set_offset(plane, mV):
@@ -179,9 +180,9 @@ def main():
     args = parser.parse_args()
     if args.verbose:
         logging.getLogger().setLevel(logging.DEBUG)
-    
+
     if not glob('/dev/cpu/*/msr'):
-        subprocess.check_call(['modprobe','msr'])
+        subprocess.check_call(['modprobe', 'msr'])
     if args.read:
         for plane in PLANES:
             msr_value = read_offset(plane)


### PR DESCRIPTION
Hey,

I added support for reading a Throttlestop file and outputting the associated command that a user can simply copy and paste if he is satisfied with the results.

I don't think it is wise to just "write to the registers" using the ThrottleStop file since it might change in the future and we wouldn't want to crash somebody's computer with faulty values.

Anyway, I realize that my Kabby lake 7700HQ (XPS 15 9560) actually saves the settings. But I figured I would contribute back anyway.

#### Sample usage
```bash
~ $ undervolt --throttlestop ThrottleStop.ini --tsindex 3
undervolt --core -100.5859375
~ $ undervolt --throttlestop ThrottleStop.ini
undervolt --core -125.0 --gpu -125.0 --cache -125.0
```