### PR TITLE
add HP Zbook Studio G5 to readme

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -154,6 +154,7 @@ Dell XPS 15 9560      i7-7700HQ Yes
 Dell XPS 15 9570      i9-8950HK Yes
 Dell XPS 15 9575      i7-8705G  Yes
 HP Spectre X360       i7-8809G  Yes
+HP Zbook Studio G5    i7-8750H  Yes
 MacBook Air Mid 2013  i5-4250U  Yes
 ===================== ========= ==========
 


### PR DESCRIPTION
Adds HP Zbook Studio G5 to README. Support was implied in the discussion for #25 but should add it to README as well.