### PR TITLE
Support AC and ACDC in /sys/class/power_supply/ 

### DIFF
--- a/undervolt.py
+++ b/undervolt.py
@@ -172,7 +172,7 @@ def read_offset(plane):
 
 
 def set_offset(plane, mV):
-    """"
+    """
     Set given voltage plane to offset mV
     Raises SystemExit if re-reading value returns something different
     """

--- a/undervolt.py
+++ b/undervolt.py
@@ -19,7 +19,7 @@ except ImportError:  # Python2
     import ConfigParser as configparser
 
 AC_STATE_NODE = os.environ.get(
-    'AC_STATE_NODE', glob('/sys/class/power_supply/AC*/online')[0])
+    'AC_STATE_NODE', (glob('/sys/class/power_supply/AC*/online') + [None])[0])
 PLANES = {
     'core': 0,
     'gpu': 1,
@@ -196,7 +196,10 @@ def read_ac_state():
     """
     Returns True if AC is connected, else False
     """
-    return open(AC_STATE_NODE).read() == '1\n'
+    if AC_STATE_NODE:
+        return open(AC_STATE_NODE).read() == '1\n'
+    # Assume no battery if the /sys entry is missing.
+    return True
 
 
 def main():

--- a/undervolt.py
+++ b/undervolt.py
@@ -12,13 +12,14 @@ import multiprocessing
 from glob import glob
 from struct import pack, unpack
 import subprocess
+from glob import glob
 try:  # Python3
     import configparser
 except ImportError:  # Python2
     import ConfigParser as configparser
 
 AC_STATE_NODE = os.environ.get(
-    'AC_STATE_NODE', '/sys/class/power_supply/AC/online')
+    'AC_STATE_NODE', glob('/sys/class/power_supply/AC*/online')[0])
 PLANES = {
     'core': 0,
     'gpu': 1,


### PR DESCRIPTION
Hello,
thanks for the excellent tool first. I had a little problem on my machine, to determine the power state the file to be read is */sys/class/power_supply/ACDC/online* instead of */sys/class/power_supply/AC/online*. This is the main fix, in addition there were 4 quotes in a docstring, trimmed to 3.