### PR TITLE
Changed variable to absolute path

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -98,7 +98,7 @@ following contents, replacing the arguments with your own offsets::
   [Service]
   Type=oneshot
   # If you have installed undervolt globally (via sudo pip install):
-  ExecStart=undervolt -v --core -150 --cache -150 --gpu -100
+  ExecStart=/usr/local/bin/undervolt -v --core -150 --cache -150 --gpu -100
   # If you want to run from source:
   # ExecStart=/path/to/undervolt.py -v --core -150 --cache -150 --gpu -100
 


### PR DESCRIPTION
Setting execStart to non absolute path leading to an error. Documentation says path should be absolute as well
https://www.freedesktop.org/software/systemd/man/systemd.exec.html

I just put path from ubuntu 18.4, I expect it to be similar, or at least easy to fix with whereis undervolt.
Approach that shouldn't work in readme is confusing for me.

Feel free to reject the PR if not agree, it was faster to create PR than an issue.