### PR TITLE
Added Powerlimit support + parameterized addresses

### DIFF
--- a/undervolt.py
+++ b/undervolt.py
@@ -39,9 +39,7 @@ PLANES = {
 }
 
 MSR = namedtuple('MSR', ['addr_voltage_offsets', 'addr_units', 'addr_power_limits', 'addr_temp'])
-ADDRESSES = {
-    '*': MSR(0x150, 0x606, 0x610, 0x1a2) # Default (Core iX 6th, 7th, 8th, 9th gen etc.)
-}
+ADDRESSES = MSR(0x150, 0x606, 0x610, 0x1a2) # Default (Core iX 6th, 7th, 8th, 9th gen etc.)
 
 # 0.2.9 removed --temp-ac flag without warning
 # accept it for now and show deprecation
@@ -365,7 +363,6 @@ def main():
                         help="extract values from ThrottleStop")
     parser.add_argument('--tsindex', type=int,
                         default=0, help="ThrottleStop profile index")
-    parser.add_argument('--cpu', default='*')
     parser.add_argument('-p1', '--power-limit-long', nargs=2, help="P1 Power Limit (W) and Time Window (s)", metavar=('POWER_LIMIT', 'TIME_WINDOW'))
     parser.add_argument('-p2', '--power-limit-short', nargs=2, help="P2 Power Limit (W) and Time Window (s)", metavar=('POWER_LIMIT', 'TIME_WINDOW'))
     parser.add_argument('--lock-power-limit', action='store_true',
@@ -383,10 +380,7 @@ def main():
     if args.verbose:
         logging.getLogger().setLevel(logging.DEBUG)
     
-    if not args.cpu in ADDRESSES:
-        logging.error("CPU {} not in known addresses!".format(args.cpu))
-        sys.exit(1)
-    msr = ADDRESSES[args.cpu]
+    msr = ADDRESSES
 
     if not glob('/dev/cpu/*/msr'):
         subprocess.check_call(['modprobe', 'msr'])

--- a/undervolt.py
+++ b/undervolt.py
@@ -206,7 +206,7 @@ def set_offset(plane, mV, msr):
     write_msr(write_value, msr.addr_voltage_offsets)
     # now check value set correctly
     want_mv = unconvert_offset(target)
-    read_mv = read_offset(plane, msr.addr_voltage_offsets)
+    read_mv = read_offset(plane, msr)
     if want_mv != read_mv:
         logging.error("Failed to apply {p}: set {t}, read {r}".format(
             p=plane, t=want_mv, r=read_mv))

--- a/undervolt.py
+++ b/undervolt.py
@@ -248,7 +248,7 @@ def read_power_limit(msr):
 # Use at your own risk!
 def set_power_limit(power_limit, msr):
     def from_seconds(val, unit):
-        # The formula 2^x*(1+y/4) has two variables and has to be solved analytically
+        # The formula 2^x*(1+y/4) has two variables and can not be solved analytically
         # y is 2 bytes, hence we only need to check 4 values
         val = val * unit
         if log2(val / 1.75) >= 0x1f:


### PR DESCRIPTION
As discussed in #92, this PR adds support to set and read the power limits P1 and P2.
Since this added more addresses, I've moved the addresses from hardcoded to a separate named tuple with the option to add support for CPUs where the MSR addresses differ (though I don't know of any where this is the case).