### PR TITLE
Check if the script is run by the root where necessary

### DIFF
--- a/undervolt.py
+++ b/undervolt.py
@@ -357,7 +357,7 @@ def assert_root():
     Checks whether the user has root privileges, exit otherwise
     """
     if os.geteuid() != 0:
-        exit("You need to have root privileges to run this script these options.\nRerun with 'sudo'.")
+        exit("You need to have root privileges to run this script with these options.\nRerun with 'sudo'.")
 
 def main():
     parser = argparse.ArgumentParser()

--- a/undervolt.py
+++ b/undervolt.py
@@ -396,7 +396,7 @@ def main():
         subprocess.check_call(['modprobe', 'msr'])
 
     if (args.core or args.cache) and args.core != args.cache:
-        logging.warn(
+        logging.warning(
             "You have supplied different offsets for Core and Cache. "
             "The smaller of the two (or none if you only supplied one) will be applied to both planes."
         )

--- a/undervolt.py
+++ b/undervolt.py
@@ -354,7 +354,7 @@ def read_ac_state():
 
 def assert_root():
     """
-    Checks whether the user has root priviliges, exit otherwise
+    Checks whether the user has root privileges, exit otherwise
     """
     if os.geteuid() != 0:
         exit("You need to have root privileges to run this script these options.\nRerun with 'sudo'.")

--- a/undervolt.py
+++ b/undervolt.py
@@ -69,6 +69,8 @@ def write_msr(val, addr):
     values from register addr.
     Writes to all msr node on all CPUs available.
     """
+    assert_root()
+    
     for i in valid_cpus():
         c = '/dev/cpu/%d/msr' % i
         if not os.path.exists(c):
@@ -84,6 +86,8 @@ def read_msr(addr, cpu=0):
     """
     Read a value from single msr node on given CPU (defaults to first)
     """
+    assert_root()
+
     n = '/dev/cpu/%d/msr' % (cpu,)
     f = os.open(n, os.O_RDONLY)
     os.lseek(f, addr, os.SEEK_SET)
@@ -348,6 +352,12 @@ def read_ac_state():
     # Assume no battery if the /sys entry is missing.
     return True
 
+def assert_root():
+    """
+    Checks whether the user has root priviliges, exit otherwise
+    """
+    if os.geteuid() != 0:
+        exit("You need to have root privileges to run this script these options.\nRerun with 'sudo'.")
 
 def main():
     parser = argparse.ArgumentParser()


### PR DESCRIPTION
Fixes #110 
Fixes #63
When I run `undervolt.py  --read` and `undervolt.py --cache -100` 
The errors given by the script as follows:
```
Traceback (most recent call last):
  File "./undervolt.py", line 470, in <module>
    main()
  File "./undervolt.py", line 449, in main
    temp = read_temperature(msr)
  File "./undervolt.py", line 195, in read_temperature
    return (read_msr(msr.addr_temp) & (127 << 24)) >> 24
  File "./undervolt.py", line 92, in read_msr
    f = os.open(n, os.O_RDONLY)
PermissionError: [Errno 13] Permission denied: '/dev/cpu/0/msr'
```

I wrote a simple assert_root function to check whether the user has root privileges to run the script with --read and --cache args. 
The user will get the following intuitive error message from the script:
```
You need to have root privileges to run this script with these options.
Rerun with 'sudo'. 
```

Also I fixed a depreciation warning in line 399
 `./undervolt.py:399: DeprecationWarning: The 'warn' function is deprecated, use 'warning' instead`
by replacing logging.warn with logging.warning
