### PR TITLE
use assert_root to check whether user is root when '-r' option is used

### DIFF
--- a/undervolt.py
+++ b/undervolt.py
@@ -357,7 +357,7 @@ def assert_root():
     Checks whether the user has root privileges, exit otherwise
     """
     if os.geteuid() != 0:
-        exit("You need to have root privileges to run this script these options.\nRerun with 'sudo'.")
+        exit("You need to have root privileges to run this script with these options.\nRerun with 'sudo'.")
 
 def main():
     parser = argparse.ArgumentParser()

--- a/undervolt.py
+++ b/undervolt.py
@@ -393,6 +393,7 @@ def main():
     msr = ADDRESSES
 
     if not glob('/dev/cpu/*/msr'):
+        assert_root()
         subprocess.check_call(['modprobe', 'msr'])
 
     if (args.core or args.cache) and args.core != args.cache:

--- a/undervolt.py
+++ b/undervolt.py
@@ -396,7 +396,7 @@ def main():
         subprocess.check_call(['modprobe', 'msr'])
 
     if (args.core or args.cache) and args.core != args.cache:
-        logging.warn(
+        logging.warning(
             "You have supplied different offsets for Core and Cache. "
             "The smaller of the two (or none if you only supplied one) will be applied to both planes."
         )

--- a/undervolt.py
+++ b/undervolt.py
@@ -354,7 +354,7 @@ def read_ac_state():
 
 def assert_root():
     """
-    Checks whether the user has root priviliges, exit otherwise
+    Checks whether the user has root privileges, exit otherwise
     """
     if os.geteuid() != 0:
         exit("You need to have root privileges to run this script these options.\nRerun with 'sudo'.")

--- a/undervolt.py
+++ b/undervolt.py
@@ -69,6 +69,8 @@ def write_msr(val, addr):
     values from register addr.
     Writes to all msr node on all CPUs available.
     """
+    assert_root()
+    
     for i in valid_cpus():
         c = '/dev/cpu/%d/msr' % i
         if not os.path.exists(c):
@@ -84,6 +86,8 @@ def read_msr(addr, cpu=0):
     """
     Read a value from single msr node on given CPU (defaults to first)
     """
+    assert_root()
+
     n = '/dev/cpu/%d/msr' % (cpu,)
     f = os.open(n, os.O_RDONLY)
     os.lseek(f, addr, os.SEEK_SET)
@@ -348,6 +352,12 @@ def read_ac_state():
     # Assume no battery if the /sys entry is missing.
     return True
 
+def assert_root():
+    """
+    Checks whether the user has root priviliges, exit otherwise
+    """
+    if os.geteuid() != 0:
+        exit("You need to have root privileges to run this script these options.\nRerun with 'sudo'.")
 
 def main():
     parser = argparse.ArgumentParser()


### PR DESCRIPTION
Closes #46 
Old version: 
```
$ undervolt -r
modprobe: ERROR: could not insert 'msr': Operation not permitted
Traceback (most recent call last):
  File "./undervolt.py", line 470, in <module>
    main()
  File "./undervolt.py", line 396, in main
    subprocess.check_call(['modprobe', 'msr'])
  File "/usr/lib/python3.8/subprocess.py", line 364, in check_call
    raise CalledProcessError(retcode, cmd)
subprocess.CalledProcessError: Command '['modprobe', 'msr']' returned non-zero exit status 1.
```
Fixed version:
```
$ undervolt -r
You need to have root privileges to run this script with these options.
Rerun with 'sudo'.
```