### PR TITLE
Intel NUC7i3BNK model, with i3-7100U CPU, works with this script. Thank you very much! :+1: 

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -231,6 +231,7 @@ Dell XPS 15 9575                   i7-8705G  Yes
 HP Omen 17-an061ur                 i7-7700HQ Yes
 HP Spectre X360                    i7-8809G  Yes
 HP Zbook Studio G5                 i7-8750H  Yes
+Intel NUC7i3BNK                    i3-7100U  Yes
 Lenovo AIO Y910 27ISH              i7-6700   Yes
 Lenovo IdeaCentre Q190             1017U     No
 Lenovo Thinkpad T430               i7-3610QM No


### PR DESCRIPTION
Confirming that the Intel NUC7i3BNK model, with i3-7100U CPU, works with this script. Thank you very much! :+1: 

Machine specifications (`inxi -F` command output):

```
  Type: Desktop System: Intel product: NUC7i3BNK v: J31188-313 
  serial: <superuser required> 
  Mobo: Intel model: NUC7i3BNB v: J22859-313 serial: <superuser required> UEFI: Intel 
  v: BNKBL357.86A.0083.2020.0714.1344 date: 07/14/2020
```

I reached about ~4C reduced temperature under 100% load (encoding h264 video), using the command:
`# ./undervolt.py --gpu -75 --core -100 --cache -100 --uncore -100 --analogio -100`

Without undervolt (stock output):
```
[root@nuc undervolt]# ./undervolt.py --read
temperature target: -0 (100C)
core: 0.0 mV
gpu: 0.0 mV
cache: 0.0 mV
uncore: 0.0 mV
analogio: 0.0 mV
powerlimit: 25.0W (short: 0.00244140625s - enabled) / 20.0W (long: 28.0s - enabled)
```

With undervolt:
```
[root@nuc undervolt]# ./undervolt.py --read
temperature target: -0 (100C)
core: -99.61 mV
gpu: -75.2 mV
cache: -99.61 mV
uncore: -99.61 mV
analogio: -99.61 mV
powerlimit: 25.0W (short: 0.00244140625s - enabled) / 20.0W (long: 28.0s - enabled)
```

Temperature when encoding H264 video (100% CPU utilization), without undervolt:
```
[user@nuc ~]$ sensors
coretemp-isa-0000
Adapter: ISA adapter
Package id 0:  +72.0°C  (high = +100.0°C, crit = +100.0°C)
Core 0:        +71.0°C  (high = +100.0°C, crit = +100.0°C)
Core 1:        +72.0°C  (high = +100.0°C, crit = +100.0°C)
```

Temperature when encoding H264 video (100% CPU utilization), with undervolt:
```
[user@nuc ~]$ sensors
coretemp-isa-0000
Adapter: ISA adapter
Package id 0:  +68.0°C  (high = +100.0°C, crit = +100.0°C)
Core 0:        +67.0°C  (high = +100.0°C, crit = +100.0°C)
Core 1:        +68.0°C  (high = +100.0°C, crit = +100.0°C)
```